### PR TITLE
Translation of yule.R to yule.jl

### DIFF
--- a/Julia/independence.jl
+++ b/Julia/independence.jl
@@ -1,0 +1,26 @@
+using Chain,
+      DataFrames,
+      Random,
+      Statistics
+
+function gap()
+    df = DataFrame(y1 = [7, 5, 5, 7, 4, 10, 1, 5, 3, 9], 
+                   y0 = [1, 6, 1, 8, 2, 1, 10, 6, 7, 8],
+                   random = randn(10))
+
+    sd0 = @chain df begin
+        sort!([:random]) 
+        insertcols!(:d => vcat(fill(1,5), fill(0,5)))
+        insertcols!(:y => df.d .* df.y1 + (1 .- df.d) .* df.y0)
+        select!(:y)
+        convert(Array, _)
+    end
+    
+    sd0 = mean(sd0[1:5]-sd0[6:10])
+
+    sd0
+end
+
+sim = [gap() for i in 1:10000]
+
+mean(sim)

--- a/Julia/yule.jl
+++ b/Julia/yule.jl
@@ -1,17 +1,35 @@
 using Chain, 
       DataFrames, 
       FileIO, 
-      GLM,
-      HTTP
+      FixedEffectModels,
+      HTTP,
+      RegressionTables
      
-
 yule = "https://raw.github.com/scunning1975/mixtape/master/yule.dta" |>
     HTTP.download |>
     load |>
     DataFrame
 
 
-yule_lm = lm(@formula(paup ~ outrelief + old + pop), yule)
+yule_lm = reg(yule, @formula(paup ~ outrelief + old + pop))                   # incorrect degrees of freedom (known issue)
+
+regtable(yule_lm, regression_statistics = [:nobs, :r2, :adjr2, :f, :p, :dof]) # correct values
+
+
+##### Alternative code using GLM #####
+
+using Chain, 
+      DataFrames, 
+      FileIO, 
+      GLM,
+      HTTP     
+
+yule = "https://raw.github.com/scunning1975/mixtape/master/yule.dta" |>
+    HTTP.download |>
+    load |>
+    DataFrame
+
+yule_lm = reg(yule, @formula(paup ~ outrelief + old + pop))
 
 # the summary() function workaround
 

--- a/Julia/yule.jl
+++ b/Julia/yule.jl
@@ -1,0 +1,23 @@
+using Chain, 
+      DataFrames, 
+      FileIO, 
+      GLM,
+      HTTP
+     
+
+yule = "https://raw.github.com/scunning1975/mixtape/master/yule.dta" |>
+    HTTP.download |>
+    load |>
+    DataFrame
+
+
+yule_lm = lm(@formula(paup ~ outrelief + old + pop), yule)
+
+# the summary() function workaround
+
+yule_lm                                      # print model            
+dof_residual(yule_lm)                        # degrees of freedom
+round(r2(yule_lm), digits = 4)               # r^2
+round(adjr2(yule_lm), digits = 4)            # r^2 adjusted
+null_model = lm(@formula(paup ~ 1), yule)    # create null null
+ftest(yule_lm.model, null_model.model)       # get the F value and significance

--- a/Julia/yule.jl
+++ b/Julia/yule.jl
@@ -19,5 +19,5 @@ yule_lm                                      # print model
 dof_residual(yule_lm)                        # degrees of freedom
 round(r2(yule_lm), digits = 4)               # r^2
 round(adjr2(yule_lm), digits = 4)            # r^2 adjusted
-null_model = lm(@formula(paup ~ 1), yule)    # create null null
+null_model = lm(@formula(paup ~ 1), yule)    # create null model
 ftest(yule_lm.model, null_model.model)       # get the F value and significance


### PR DESCRIPTION
As Julia does not seem to have an ubiquotuous function like summary(), I wrote a workaround where all the values of summary() called on a linear model object in R are printed out separately. 

Should this be more verbose with the print function? E.g. print("The R^2 value is XY.Z")